### PR TITLE
Make Rasengan chargeable and compatible with beam clash

### DIFF
--- a/Naruto/scripts/_readme.gml
+++ b/Naruto/scripts/_readme.gml
@@ -473,3 +473,6 @@ Compatibility --> Muno Character Compatibility
 
 
 
+
+// Rasengan dash and clash
+// Hold special to charge, release to dash forward. If your Rasengan collides with another beam, mash Special to win the clash.

--- a/Naruto/scripts/attacks/nspecial.gml
+++ b/Naruto/scripts/attacks/nspecial.gml
@@ -1,202 +1,97 @@
-//----------------------------------------------------------------------------------------------------
-// NSPECIAL
-//----------------------------------------------------------------------------------------------------
-
-//rasengan
-
 set_attack_value(AT_NSPECIAL, AG_CATEGORY, 2);
 set_attack_value(AT_NSPECIAL, AG_SPRITE, sprite_get("nspecial"));
-set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 10);
+set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 8);
+set_attack_value(AT_NSPECIAL, AG_HAS_LANDING_LAG, 4);
+set_attack_value(AT_NSPECIAL, AG_OFF_LEDGE, 1);
 set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, sprite_get("nspecial_hurt"));
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_COOLDOWN, 120);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_CD_SPECIAL, 1);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_MISC_ADD, "The Rasengan now dashes forward and can clash with beams.");
 
-
-//startup
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 2);
+// startup
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 10);
 set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAME_START, 0);
 
-//summon clone if necessary
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 2);
+// charge loop
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 3);
 set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 2);
+set_window_value(AT_NSPECIAL, 2, AG_MUNO_WINDOW_EXCLUDE, 1);
 
-//; wait until clone is ready
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_TYPE, 9); //infinitely-repeating window
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 2);
+// post-charge
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 16);
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 4);
 set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 2);
 
-//startup 2
+// dash overshoot
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 3);
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 4);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 12);
 
-//charge rasengan
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9); //infinitely-repeating window
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 6);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 5);
+// dash loop
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 3);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//fire rasengan startup
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 7);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HAS_SFX, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_SFX, asset_get("sfx_forsburn_cape_swipe"));
+// final hit
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 5);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//fire rasengan active
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 6);
+// endlag
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 12); // also change in atk update
 set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 9);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_VSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//recovery 1  (hold pose)
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 10);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 12);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_VSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED_TYPE, 2);
+// endlag pt 2
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 16);
 
-//recovery 2
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAME_START, 13);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_ENDLAG, string(get_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH)));
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_MISC_ADD, "Endlag increases with charge.");
 
-//recovery 3
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAME_START, 14);
+set_num_hitboxes(AT_NSPECIAL, 0);
 
-
-//--------------------
-// NSPECIAL Hitboxes
-//--------------------
-
-
-set_num_hitboxes(AT_NSPECIAL, 3);
-
-//rasengan - initial hitbox
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_X, 24);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_Y, -24);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 4);
+set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 1);
 set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 64);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 8); //must be higher than 1
+set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_DAMAGE, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 30);
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 6);
-set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 70);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
+set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.00001);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, sfx_dbfz_hit_weak);
+set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_MUNO_HITBOX_ACTIVE, "16");
+set_hitbox_value(AT_NSPECIAL, 1, HG_MUNO_HITBOX_NAME, "Multihit");
 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_ANIM_SPEED, 0.5); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_HSPEED, 15); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 1, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - travelling multihit hitbox - spawned in hit_player.gml
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 30);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_Y, -30);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 1); // stats updated in hit_player.gml
+set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 6);
+set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 64);
 set_hitbox_value(AT_NSPECIAL, 2, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 5); //must be higher than 1
-set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 3);
+set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 4);
 set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE, 45);
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 9); //hit in direction of projectile
-set_hitbox_value(AT_NSPECIAL, 2, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, 7);
+set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0.8);
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 9);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0.5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ANIM_SPEED, 0.33); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED, 5); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ENEMY_BEHAVIOR, 1); //goes through players - important 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, get_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED)); //knockback speed = travel speed
-set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 2, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - final hitbox - spawned in hitbox.gml upon hitbox #2's final hit
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_LIFETIME, 4);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_Y, -30);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WIDTH, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HEIGHT, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PRIORITY, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_DAMAGE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE, 55);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 8); //hit towards projectile
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_KNOCKBACK, 8); //adjust as needed
-set_hitbox_value(AT_NSPECIAL, 3, HG_KNOCKBACK_SCALING, 0.9); //important
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_HITPAUSE, 9);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITPAUSE_SCALING, 0.5);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SDI_MULTIPLIER, 1); 
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ANIM_SPEED, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_MASK, -1);
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_HSPEED, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_IS_TRANSCENDENT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ENEMY_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, sfx_dbfz_hit_jab3);
+set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_MUNO_HITBOX_ACTIVE, "23");
+set_hitbox_value(AT_NSPECIAL, 2, HG_MUNO_HITBOX_NAME, "Finisher");

--- a/Naruto/scripts/hit_player.gml
+++ b/Naruto/scripts/hit_player.gml
@@ -3,7 +3,21 @@
 
 //keep track of the last player that the real Naruto successfully hit. If the player is on the same team, don't count it.
 if (is_master_player && hit_player_obj.state_cat == SC_HITSTUN && get_player_team(hit_player_obj.player) != get_player_team(player)) {
-	naruto_last_hit_opponent = hit_player_obj;
+        naruto_last_hit_opponent = hit_player_obj;
+}
+
+if (my_hitboxID.attack == AT_NSPECIAL && !has_updated_beam_kb) {
+        has_updated_beam_kb = true;
+        set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, lerp(7, 12, beam_juice / beam_juice_max));
+        set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, lerp(0.5, 1.6, beam_juice / beam_juice_max));
+        set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, lerp(8, 20, beam_juice / beam_juice_max));
+        set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, lerp(0.5, 1.5, beam_juice / beam_juice_max));
+        set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, lerp(2, 22, beam_juice / beam_juice_max));
+        set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE, round(lerp(55, 35, beam_juice / beam_juice_max)));
+}
+
+if (my_hitboxID.attack == AT_NSPECIAL && my_hitboxID.hbox_num == 2 && my_hitboxID.hitpause > 15) {
+        sound_play(sfx_dbfz_hit_broken);
 }
 
 

--- a/Naruto/scripts/load.gml
+++ b/Naruto/scripts/load.gml
@@ -62,10 +62,6 @@ sprite_change_offset("dstrong", 50, 70);
 sprite_change_offset("dstrong_hurt", 100, 140);
 sprite_change_offset("nspecial", 50, 70);
 sprite_change_offset("nspecial_hurt", 100, 140);
-sprite_change_offset("nspecial_beam_start", 50, 70);
-sprite_change_offset("nspecial_beam_end", 50, 70);
-sprite_change_offset("nspecial_beam_loop", 50, 70);
-sprite_change_offset("nspecial_beam_fade", 50, 70);
 sprite_change_offset("vfx_nspecial_fire", 50, 70);
 sprite_change_offset("vfx_ftilt_destroy", 50, 70); // actually for nspecial, not ftilt
 sprite_change_offset("fspecial", 50, 70);


### PR DESCRIPTION
## Summary
- rework Naruto's neutral special so Rasengan charges, dashes and can clash with beams
- sync hitbox scaling with charge level
- remove unused beam sprites from sprite load list
- document the new dash clash mechanic in the readme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d0875d9e08332befd21a2d1963d3e