### PR TITLE
Clone Goku neutral special onto Naruto

### DIFF
--- a/Naruto/scripts/attack_update.gml
+++ b/Naruto/scripts/attack_update.gml
@@ -234,154 +234,227 @@ switch(attack) {
 	
 	break;
 	
-	case AT_NSPECIAL:
-		//rasengan
-		
-		
-		
-		can_move = false;
-		//slow down movement if in the air
-		if (free) hsp *= 0.99;
-		
-		switch (window) {
-			
-			case 2: //startup
-				if (window_timer != 1) break;
-				//if at full charge, skip this window
-				//if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge) {
-				//	window++;
-				//	window_timer = 0;
-				//	break;
-				//}
-				
-				//if a clone is nearby, use that clone instead of summoning a new one.
-				naruto_spawned_clone_reference = get_nearest_clone(c_naruto_clone_teamup_max_distance);
-				if (naruto_spawned_clone_reference != noone) {
-					//if a clone was found, set this clone's attack to AT_NSPECIAL_2.
-					clone_teamup_effect();
-					with (naruto_spawned_clone_reference) {
-						safely_set_attack(AT_NSPECIAL_2);
-						//skip startup window.
-						window++;
-						window_timer = 0;
-					}
-				}
-				else {
-					//if no clone was found, spawn a new clone, with the default startup time.
-					naruto_spawned_clone_reference = spawn_clone(x - spr_dir * 30, y);
-					if instance_exists(naruto_spawned_clone_reference) {
-						with (naruto_spawned_clone_reference) { safely_set_attack(AT_NSPECIAL_2);  }
-						spawn_hit_fx_2x(naruto_spawned_clone_reference.x, y, vfx_clone_smoke).depth = depth-1;
-					}
-				}
-			break;
-			
-			case 3: //wait for clone
-				//cycle this window until the clone is ready to help charge.
-				//skip ahead if this move is at max charge.
-				//if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge && !special_down) {
-				//	window += 3;
-				//	window_timer = 0;
-				//	break;
-				//}
-				
-				//cancel this attack if the clone has gone away, or isn't using the right attack
-				if (!clone_exists_and_is_using_attack(naruto_spawned_clone_reference, AT_NSPECIAL_2)) {
-					window = 9;
-					window_timer = 0;
-					break;
-				}
-				//when the clone reaches window 3 of at_nspecial_2, transition the player to the next window of at_nspecial.
-				if (naruto_spawned_clone_reference.window >= 3) {
-					window++;
-					window_timer = 0;
-					//clear the relevant button buffers, so that you can't cancel the attack -before- the charge window starts.
-					//clear_button_buffer(PC_LEFT_HARD_PRESSED);
-					//clear_button_buffer(PC_RIGHT_HARD_PRESSED);
-					clear_button_buffer(PC_SHIELD_PRESSED);
-					
-				}
-			break;
-			
-			case 5: //charge window
-				vsp = min(vsp, c_naruto_nspecial_max_fall_speed);
-				
-				//cancel this attack with a hard left/right press, or with the shield button
-				//var hard_press_dir = left_hard_pressed - right_hard_pressed;
-				//if (left_hard_pressed - right_hard_pressed != 0 || shield_pressed || jump_pressed) {
-				
-				//cancel this attack with a dodge.
-				if (shield_pressed) {
-					
-					print("shield pressed")
-					if (!free) {
-						//on the ground: cancel into a roll.
-						//clear_button_buffer(PC_SHIELD_PRESSED);
-						
-						switch ((right_down - left_down) * spr_dir) {
-							
-							case 1: 
-								set_state(PS_ROLL_FORWARD);
-							break;
-							case -1: 
-								
-								set_state(PS_ROLL_BACKWARD);
-							break;
-							default:
-								window = 9;
-								window_timer = 0;
-							break;
-						}
-					}
-					else {
-						//in the air: cancel into an airdodge if possible.
-						if (has_airdodge) {
-							has_airdodge = 0;
-							set_state(PS_AIR_DODGE);
-							//clear_button_buffer(PC_SHIELD_PRESSED);
-						}
-						//if no airdodge, cancel into nspecial's recovery.
-						else {
-							window = 9;
-							window_timer = 0;
-						}
-					}
-				}
-
-				//stop charging if the special button is not held
-				else if (!special_down) {
-					window++;
-					window_timer = 0;
-					break;
-				}
-				
-				//charging sfx
-				if (naruto_nspecial_charge == 1 && naruto_nspecial_charge != c_naruto_nspecial_max_charge) {
-					voice_play(VB_RASENGAN_CHARGING);
-					naruto_nspecial_sound = sound_play(sound_get("snd_rasenganstartcharge"), 0, noone, 0.8, 1)
-				}
-				
-				//charge up
-				var check_full_charge = (naruto_nspecial_charge >= c_naruto_nspecial_max_charge);
-				naruto_nspecial_charge = min(naruto_nspecial_charge + 1, c_naruto_nspecial_max_charge);
-				if (!check_full_charge && naruto_nspecial_charge >= c_naruto_nspecial_max_charge) {
-					voice_play(VB_RASENGAN_FULLCHARGE);
-				}
-			break;
-			
-			case 6:
-				//limit fall speed
-				vsp = min(vsp, c_naruto_nspecial_max_fall_speed);
-				
-				//play voice sfx at end of window
-				if (!is_end_of_window()) break;
-				if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge) voice_play(VB_RASENGAN_MAX);
-				else voice_play(VB_RASENGAN);
-			break;
-			
-		}
-	break;
 	
+	
+	case AT_NSPECIAL:
+                var phone_window_end = get_window_value(attack, window, AG_WINDOW_LENGTH);
+		switch(window){
+			case 1: // startup
+				if window_timer == 1{
+        beam_juice = 60;
+					beam_juice_max = 60 * 8;
+					beam_length = 0; // current length of beam
+					hsp = clamp(hsp, -2, 2);
+					vsp = min(vsp, 3);
+					has_updated_beam_kb = false;
+					beam_clash_buddy = noone;
+					beam_clash_timer = 0;
+					beam_clash_timer_max = 120;
+					beam_angle = 0;
+				}
+				if window_timer == phone_window_end{
+					beam_angle = point_direction(0, 0, lengthdir_x(1, beam_angle) * spr_dir, lengthdir_y(1, beam_angle));
+					voice_play(VB_KAMEHAME);
+				}
+				can_fast_fall = false;
+				break;
+			case 2: // charge loop
+				if window_timer == 1{
+					sound_play(sfx_dbfz_kame_charge, false, noone, 1, 1 + beam_juice * 0.001);
+				}
+				if beam_juice > 180{
+					shake_camera(floor((beam_juice - 180) / 30), 1);
+				}
+				//switch((right_down - left_down) * spr_dir)
+					//default:
+						//beam_angle = 30;
+						//break;
+					//case 1:
+						//beam_angle = 15;
+						//break;
+					//case -1:
+						//beam_angle = 45;
+						//break;
+				//}
+				/*
+				beam_angle *= (up_down - down_down);
+				beam_angle = (beam_angle + 360) % 360;
+				beam_angle = point_direction(0, 0, lengthdir_x(1, beam_angle) * spr_dir, lengthdir_y(1, beam_angle));
+				*/
+				
+				if special_down && beam_juice < beam_juice_max{
+					beam_juice++;
+				}
+				else{
+					window++;
+					window_timer = 0;
+					sound_play(sfx_dbfz_swipe_weak1);
+					sound_play(asset_get("mfx_star"), false, noone, 1, 1.2);
+					var hfx = spawn_hit_fx(x - 24 * spr_dir, y - 38, 305);
+					hfx.depth = depth - 3;
+					array_push(phone_dust_query, [x, y, "land", spr_dir]);
+					
+					var x1 = x + 72 * spr_dir;
+					var y1 = y - 40 + lengthdir_y(32, beam_angle);
+					
+					switch((abs(lengthdir_y(1, beam_angle)) > abs(lengthdir_y(1, 15))) * sign(lengthdir_y(1, beam_angle))){
+						case 1: // down
+							x1 = x + 74 * spr_dir;
+							y1 = y - 6;
+							break;
+						case -1: // up
+							x1 = x + 60 * spr_dir;
+							y1 = y - 72;
+							break;
+					}
+					
+					var h = spawn_hit_fx(x1, y1, vfx_ftilt_destroy);
+					h.spr_dir = 1;
+					h.draw_angle = beam_angle;
+					h.depth = depth - 1;
+				}
+				hsp = clamp(hsp, -2, 2);
+				vsp = min(vsp, 3);
+				can_fast_fall = false;
+				
+				if window_timer == phone_window_end || window_timer == phone_window_end - 3|| window_timer == phone_window_end - 6{
+					spawn_base_dust(x - 20 * spr_dir + sin(window_timer + 2) * 6 * spr_dir, y, beam_juice > 300 ? "dash_start" : (beam_juice > 180 ? "dash" : "walk"));
+				}
+				break;
+			case 3: // post-charge
+				hsp = 0;
+				vsp = 0;
+				can_move = false;
+				can_fast_fall = false;
+				was_fully_charged = (beam_juice >= beam_juice_max);
+				if window_timer == 13{ // 1
+					voice_play(VB_HA);
+					
+					// also change in nspecial.gml
+					set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 16 + floor(ease_sineIn(0, 30, beam_juice, beam_juice_max)));
+				}
+				if window_timer == phone_window_end{
+					spawn_nspecial_hitbox(1);
+					sound_play(sfx_dbfz_kame_fire);
+					spawn_base_dust(x, y, "dash_start");
+					
+					var x1 = x + 72 * spr_dir;
+					var y1 = y - 40 + lengthdir_y(32, beam_angle);
+					
+					switch((abs(lengthdir_y(1, beam_angle)) > abs(lengthdir_y(1, 15))) * sign(lengthdir_y(1, beam_angle))){
+						case 1: // down
+							x1 = x + 74 * spr_dir;
+							y1 = y - 6;
+							break;
+						case -1: // up
+							x1 = x + 60 * spr_dir;
+							y1 = y - 72;
+							break;
+					}
+					
+					var h = spawn_hit_fx(x1, y1, vfx_nspecial_fire);
+					h.spr_dir = 1;
+					h.draw_angle = beam_angle;
+					h.depth = depth - 1;
+				}
+				break;
+			case 5: // beam loop
+				if beam_juice <= 0{
+					window++;
+					window_timer = 0;
+					spawn_nspecial_hitbox(2);
+				}
+				hsp = 0;
+				vsp = 0;
+				can_move = false;
+				can_fast_fall = false;
+				
+				if window_timer % 2{
+					spawn_base_dust(x - 20 * spr_dir + sin(window_timer + 2) * 6 * spr_dir, y, "dash");
+				}
+				shake_camera(1, 1);
+			case 4: // beam overshoot
+				if beam_clash_buddy != noone{
+					beam_clash_logic();
+				}
+				else if !was_fully_charged && !hitpause && (was_parried || has_hit || place_meeting(x + lengthdir_x(beam_length + 32, beam_angle), y + lengthdir_y(beam_length, beam_angle), asset_get("par_block"))){
+					if beam_juice > 0{
+						beam_juice -= 10;
+					}
+				}
+				else if !hitpause{
+					if beam_juice > 0{
+						beam_length += 32 + 64 * was_fully_charged;
+						beam_juice -= 10;
+					}
+				}
+				if window != 6{
+					spawn_nspecial_hitbox(1);
+					
+					if beam_clash_buddy == noone{
+						var me = self;
+						with oPlayer if "has_goku_beam" in self && doing_goku_beam && abs((me.beam_angle + 180) % 360 - beam_angle % 360) < 5 && instance_exists(beam_newest_hbox){
+							var him = self;
+							with beam_newest_hbox if distance_to_object(me.beam_newest_hbox) < (32 + 64 * (me.was_fully_charged || him.was_fully_charged)){
+								me.beam_clash_buddy = him;
+								him.beam_clash_buddy = me;
+								with me sound_play(sfx_dbfz_hit_broken);
+								me.beam_juice = max(me.beam_juice, 30);
+								him.beam_juice = max(him.beam_juice, 30);
+								me.beam_clash_timer_max = max(me.beam_clash_timer_max, him.beam_clash_timer_max);
+								him.beam_clash_timer_max = max(me.beam_clash_timer_max, him.beam_clash_timer_max);
+							}
+						}
+					}
+				}
+				
+				hsp = 0;
+				vsp = 0;
+				can_move = false;
+				can_fast_fall = false;
+				shake_camera(4, 1);
+				break;
+			case 6: // last hit
+				if beam_clash_buddy != noone{
+					beam_clash_logic();
+				}
+				else if window_timer == phone_window_end{
+		
+					var x1 = x + 72 * spr_dir;
+					var y1 = y - 40 + lengthdir_y(32, beam_angle);
+					
+					switch((abs(lengthdir_y(1, beam_angle)) > abs(lengthdir_y(1, 15))) * sign(lengthdir_y(1, beam_angle))){
+						case 1: // down
+							x1 = x + 74 * spr_dir;
+							y1 = y - 6;
+							break;
+						case -1: // up
+							x1 = x + 60 * spr_dir;
+							y1 = y - 72;
+							break;
+					}
+					
+					var h = spawn_hit_fx(x1 + lengthdir_x(beam_length - 34, beam_angle), y1 + lengthdir_y(beam_length - 34, beam_angle), vfx_ftilt_destroy);
+					h.spr_dir = 1;
+					h.draw_angle = beam_angle;
+					h.depth = depth;
+				}
+				hsp = 0;
+				vsp = 0;
+				can_move = false;
+				can_fast_fall = false;
+				break;
+			case 7: // endlag
+				hsp = 0;
+				vsp = 0;
+				can_move = false;
+				can_fast_fall = false;
+				break;
+			case 8: // endlag pt 2
+				set_window_value(attack, window, AG_WINDOW_TYPE, 7 * free);
+				break;
+		}
+		break;
 	case AT_NSPECIAL_2:
 		//'clone' part of nspecial.
 		var master_is_using_nspecial;
@@ -1162,6 +1235,48 @@ else{
 	}
 }
 
+#define spawn_nspecial_hitbox(num)
+
+if hitpause && num == 1 return;
+
+attack_end();
+
+var x1 = 72;
+var y1 = -40 + lengthdir_y(32, beam_angle);
+
+switch((abs(lengthdir_y(1, beam_angle)) > abs(lengthdir_y(1, 15))) * sign(lengthdir_y(1, beam_angle))){
+        case 1: // down
+                x1 = 74;
+                y1 = -6;
+                break;
+        case -1: // up
+                x1 = 60;
+                y1 = -72;
+                break;
+}
+
+var cur_x = x1;
+var cur_y = y1;
+
+set_hitbox_value(attack, num, HG_WIDTH, 64 + 16 * has_hit);
+set_hitbox_value(attack, num, HG_HEIGHT, 64 + 16 * has_hit);
+
+var ld_x = lengthdir_x(32, beam_angle) * spr_dir;
+var ld_y = lengthdir_y(32, beam_angle);
+
+for (var i = 0; i * 32 < beam_length && i < 32 && cur_x == clamp(cur_x, -64, room_width + 64); i++){
+        if i % 3 == 0 || (i+1) * 32 >= beam_length{
+                if (i+1) * 32 >= beam_length{
+                        set_hitbox_value(attack, num, HG_WIDTH, 64 + 64 * has_hit);
+                        set_hitbox_value(attack, num, HG_HEIGHT, 64 + 64 * has_hit);
+                }
+                beam_newest_hbox = create_hitbox(attack, num, round(x + cur_x * spr_dir), round(y + cur_y));
+                beam_newest_hbox.x_pos = round(cur_x * spr_dir);
+                beam_newest_hbox.y_pos = round(cur_y);
+        }
+        cur_x += ld_x;
+        cur_y += ld_y;
+}
 
 
 

--- a/Naruto/scripts/attacks/nspecial.gml
+++ b/Naruto/scripts/attacks/nspecial.gml
@@ -1,202 +1,98 @@
-//----------------------------------------------------------------------------------------------------
-// NSPECIAL
-//----------------------------------------------------------------------------------------------------
-
-//rasengan
-
 set_attack_value(AT_NSPECIAL, AG_CATEGORY, 2);
 set_attack_value(AT_NSPECIAL, AG_SPRITE, sprite_get("nspecial"));
-set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 10);
-set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, sprite_get("nspecial_hurt"));
+set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 8);
+set_attack_value(AT_NSPECIAL, AG_HAS_LANDING_LAG, 4);
+set_attack_value(AT_NSPECIAL, AG_OFF_LEDGE, 1);
+set_attack_value(AT_NSPECIAL, AG_AIR_SPRITE, sprite_get("nspecial_air"));
+set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, hurtbox_spr);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_COOLDOWN, 120);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_CD_SPECIAL, 1);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_MISC_ADD, "The number of multi-hits, as well as the final hit's power, will change depending on A) the charge of the move and B) the distance from the opponent.");
 
-
-//startup
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 2);
+// startup
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 10);
 set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAME_START, 0);
 
-//summon clone if necessary
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 2);
+// charge loop
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 3);
 set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 2);
+set_window_value(AT_NSPECIAL, 2, AG_MUNO_WINDOW_EXCLUDE, 1);
 
-//; wait until clone is ready
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_TYPE, 9); //infinitely-repeating window
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 2);
+// post-charge
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 16); // 4
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 4); // 1
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 2); // 5
 
-//startup 2
+// beam overshoot
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 3);
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 4);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 12);
 
-//charge rasengan
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9); //infinitely-repeating window
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 6);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 5);
+// beam loop
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 3);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//fire rasengan startup
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 7);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HAS_SFX, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_SFX, asset_get("sfx_forsburn_cape_swipe"));
+// last hit
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 5);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//fire rasengan active
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 6);
+// endlag
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 12); // also change in atk update
 set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 9);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_VSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 13);
 
-//recovery 1  (hold pose)
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 10);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 12);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_VSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED_TYPE, 2);
+// endlag pt 2
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 16);
 
-//recovery 2
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAME_START, 13);
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_ENDLAG, string(get_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH)));
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_MISC_ADD, "Endlag increases with charge.");
 
-//recovery 3
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAME_START, 14);
+set_num_hitboxes(AT_NSPECIAL, 0);
 
-
-//--------------------
-// NSPECIAL Hitboxes
-//--------------------
-
-
-set_num_hitboxes(AT_NSPECIAL, 3);
-
-//rasengan - initial hitbox
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_X, 24);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_Y, -24);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 4);
+set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 1);
 set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 64);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 8); //must be higher than 1
+set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_DAMAGE, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 30);
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 6);
-set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 70);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
+set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.00001);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, sfx_dbfz_hit_weak);
+set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_MUNO_HITBOX_ACTIVE, "16");
+set_hitbox_value(AT_NSPECIAL, 1, HG_MUNO_HITBOX_NAME, "Multihit");
 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_ANIM_SPEED, 0.5); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_HSPEED, 15); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 1, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - travelling multihit hitbox - spawned in hit_player.gml
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 30);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_Y, -30);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 1); // also change these stats in hit_player.gml
+set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 6);
+set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 64);
 set_hitbox_value(AT_NSPECIAL, 2, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 5); //must be higher than 1
-set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 3);
+set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 4);
 set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE, 45);
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 9); //hit in direction of projectile
-set_hitbox_value(AT_NSPECIAL, 2, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ANIM_SPEED, 0.33); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED, 5); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ENEMY_BEHAVIOR, 1); //goes through players - important 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, get_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED)); //knockback speed = travel speed
-set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 2, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - final hitbox - spawned in hitbox.gml upon hitbox #2's final hit
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_LIFETIME, 4);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_Y, -30);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WIDTH, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HEIGHT, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PRIORITY, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_DAMAGE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE, 55);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 8); //hit towards projectile
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_KNOCKBACK, 8); //adjust as needed
-set_hitbox_value(AT_NSPECIAL, 3, HG_KNOCKBACK_SCALING, 0.9); //important
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_HITPAUSE, 9);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITPAUSE_SCALING, 0.5);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SDI_MULTIPLIER, 1); 
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ANIM_SPEED, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_MASK, -1);
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_HSPEED, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_IS_TRANSCENDENT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ENEMY_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, 7);
+set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0.8);
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 9);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0.5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 304);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, sfx_dbfz_hit_jab3);
+set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_MUNO_HITBOX_ACTIVE, "23");
+set_hitbox_value(AT_NSPECIAL, 2, HG_MUNO_HITBOX_NAME, "Finisher");

--- a/Naruto/scripts/attacks/nspecial_rasengan.gml
+++ b/Naruto/scripts/attacks/nspecial_rasengan.gml
@@ -1,0 +1,202 @@
+//----------------------------------------------------------------------------------------------------
+// NSPECIAL
+//----------------------------------------------------------------------------------------------------
+
+//rasengan
+
+set_attack_value(AT_NSPECIAL, AG_CATEGORY, 2);
+set_attack_value(AT_NSPECIAL, AG_SPRITE, sprite_get("nspecial"));
+set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 10);
+set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, sprite_get("nspecial_hurt"));
+
+
+//startup
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 2);
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAME_START, 0);
+
+//summon clone if necessary
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 4);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 2);
+
+//; wait until clone is ready
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_TYPE, 9); //infinitely-repeating window
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 4);
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 2);
+
+//startup 2
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 3);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 4);
+
+//charge rasengan
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9); //infinitely-repeating window
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 6);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 5);
+
+//fire rasengan startup
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 4);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 7);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED, 4);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HAS_SFX, 1);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_SFX, asset_get("sfx_forsburn_cape_swipe"));
+
+//fire rasengan active
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 6);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 3);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 9);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED, 3);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_VSPEED_TYPE, 1);
+
+//recovery 1  (hold pose)
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 10);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 12);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_VSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED, 1);
+set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED_TYPE, 2);
+
+//recovery 2
+set_window_value(AT_NSPECIAL, 9, AG_WINDOW_LENGTH, 4);
+set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAME_START, 13);
+
+//recovery 3
+set_window_value(AT_NSPECIAL, 10, AG_WINDOW_LENGTH, 4);
+set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAME_START, 14);
+
+
+//--------------------
+// NSPECIAL Hitboxes
+//--------------------
+
+
+set_num_hitboxes(AT_NSPECIAL, 3);
+
+//rasengan - initial hitbox
+
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 2);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 7);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW_CREATION_FRAME, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 7);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_X, 24);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_Y, -24);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 64);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 64);
+set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 8); //must be higher than 1
+set_hitbox_value(AT_NSPECIAL, 1, HG_DAMAGE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 30);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 6);
+set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0); //important
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITPAUSE_SCALING, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT_Y_OFFSET, -16);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
+set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE_FLIPPER, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_LOCKOUT, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
+
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_ANIM_SPEED, 0.5); 
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_MASK, -1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
+
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_HSPEED, 15); 
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_VSPEED, 0); 
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
+set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_PARRY_STUN, 1); 
+set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
+set_hitbox_value(AT_NSPECIAL, 1, HG_TECHABLE, 1); //can't ground tech
+
+//rasengan - travelling multihit hitbox - spawned in hit_player.gml
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 2);
+set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 20);
+set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW_CREATION_FRAME, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 30);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_X, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_Y, -30);
+set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 64);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HEIGHT, 64);
+set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 5); //must be higher than 1
+set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE, 45);
+set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 9); //hit in direction of projectile
+set_hitbox_value(AT_NSPECIAL, 2, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
+
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 2);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT_Y_OFFSET, -16);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
+set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
+
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ANIM_SPEED, 0.33); 
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_MASK, -1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
+
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED, 5); 
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_VSPEED, 0); 
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ENEMY_BEHAVIOR, 1); //goes through players - important 
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 0);
+
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, get_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED)); //knockback speed = travel speed
+set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0); //important
+set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_PARRY_STUN, 1); 
+set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
+set_hitbox_value(AT_NSPECIAL, 2, HG_TECHABLE, 1); //can't ground tech
+
+//rasengan - final hitbox - spawned in hitbox.gml upon hitbox #2's final hit
+set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_TYPE, 2);
+set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW, 20);
+set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW_CREATION_FRAME, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_LIFETIME, 4);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_X, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_Y, -30);
+set_hitbox_value(AT_NSPECIAL, 3, HG_WIDTH, 70);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HEIGHT, 70);
+set_hitbox_value(AT_NSPECIAL, 3, HG_SHAPE, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_PRIORITY, 8); 
+set_hitbox_value(AT_NSPECIAL, 3, HG_DAMAGE, 2);
+set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE, 55);
+set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 8); //hit towards projectile
+set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_KNOCKBACK, 8); //adjust as needed
+set_hitbox_value(AT_NSPECIAL, 3, HG_KNOCKBACK_SCALING, 0.9); //important
+set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_HITPAUSE, 9);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HITPAUSE_SCALING, 0.5);
+set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT_Y_OFFSET, -16);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
+set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_LOCKOUT, 1);
+set_hitbox_value(AT_NSPECIAL, 3, HG_SDI_MULTIPLIER, 1); 
+
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ANIM_SPEED, 1); 
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_MASK, -1);
+
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_HSPEED, 8); 
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_VSPEED, 0); 
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_IS_TRANSCENDENT, 1);
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ENEMY_BEHAVIOR, 1);
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
+set_hitbox_value(AT_NSPECIAL, 3, HG_IGNORES_PROJECTILES, 0);
+set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_PARRY_STUN, 1); 
+set_hitbox_value(AT_NSPECIAL, 3, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun


### PR DESCRIPTION
## Summary
- copy Goku's nspecial attack to Naruto as the default nspecial
- replace Naruto's nspecial logic in `attack_update.gml` with Goku's beam variant
- keep original Rasengan script as `nspecial_rasengan.gml`
- add helper macro `spawn_nspecial_hitbox`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884a4ce6cfc8332bd1758c125aadad7