### PR TITLE
Add basic rasengan dash special

### DIFF
--- a/Naruto/scripts/attack_update.gml
+++ b/Naruto/scripts/attack_update.gml
@@ -234,152 +234,50 @@ switch(attack) {
 	
 	break;
 	
-	case AT_NSPECIAL:
-		//rasengan
-		
-		
-		
-		can_move = false;
-		//slow down movement if in the air
-		if (free) hsp *= 0.99;
-		
-		switch (window) {
-			
-			case 2: //startup
-				if (window_timer != 1) break;
-				//if at full charge, skip this window
-				//if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge) {
-				//	window++;
-				//	window_timer = 0;
-				//	break;
-				//}
-				
-				//if a clone is nearby, use that clone instead of summoning a new one.
-				naruto_spawned_clone_reference = get_nearest_clone(c_naruto_clone_teamup_max_distance);
-				if (naruto_spawned_clone_reference != noone) {
-					//if a clone was found, set this clone's attack to AT_NSPECIAL_2.
-					clone_teamup_effect();
-					with (naruto_spawned_clone_reference) {
-						safely_set_attack(AT_NSPECIAL_2);
-						//skip startup window.
-						window++;
-						window_timer = 0;
-					}
-				}
-				else {
-					//if no clone was found, spawn a new clone, with the default startup time.
-					naruto_spawned_clone_reference = spawn_clone(x - spr_dir * 30, y);
-					if instance_exists(naruto_spawned_clone_reference) {
-						with (naruto_spawned_clone_reference) { safely_set_attack(AT_NSPECIAL_2);  }
-						spawn_hit_fx_2x(naruto_spawned_clone_reference.x, y, vfx_clone_smoke).depth = depth-1;
-					}
-				}
-			break;
-			
-			case 3: //wait for clone
-				//cycle this window until the clone is ready to help charge.
-				//skip ahead if this move is at max charge.
-				//if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge && !special_down) {
-				//	window += 3;
-				//	window_timer = 0;
-				//	break;
-				//}
-				
-				//cancel this attack if the clone has gone away, or isn't using the right attack
-				if (!clone_exists_and_is_using_attack(naruto_spawned_clone_reference, AT_NSPECIAL_2)) {
-					window = 9;
-					window_timer = 0;
-					break;
-				}
-				//when the clone reaches window 3 of at_nspecial_2, transition the player to the next window of at_nspecial.
-				if (naruto_spawned_clone_reference.window >= 3) {
-					window++;
-					window_timer = 0;
-					//clear the relevant button buffers, so that you can't cancel the attack -before- the charge window starts.
-					//clear_button_buffer(PC_LEFT_HARD_PRESSED);
-					//clear_button_buffer(PC_RIGHT_HARD_PRESSED);
-					clear_button_buffer(PC_SHIELD_PRESSED);
-					
-				}
-			break;
-			
-			case 5: //charge window
-				vsp = min(vsp, c_naruto_nspecial_max_fall_speed);
-				
-				//cancel this attack with a hard left/right press, or with the shield button
-				//var hard_press_dir = left_hard_pressed - right_hard_pressed;
-				//if (left_hard_pressed - right_hard_pressed != 0 || shield_pressed || jump_pressed) {
-				
-				//cancel this attack with a dodge.
-				if (shield_pressed) {
-					
-					print("shield pressed")
-					if (!free) {
-						//on the ground: cancel into a roll.
-						//clear_button_buffer(PC_SHIELD_PRESSED);
-						
-						switch ((right_down - left_down) * spr_dir) {
-							
-							case 1: 
-								set_state(PS_ROLL_FORWARD);
-							break;
-							case -1: 
-								
-								set_state(PS_ROLL_BACKWARD);
-							break;
-							default:
-								window = 9;
-								window_timer = 0;
-							break;
-						}
-					}
-					else {
-						//in the air: cancel into an airdodge if possible.
-						if (has_airdodge) {
-							has_airdodge = 0;
-							set_state(PS_AIR_DODGE);
-							//clear_button_buffer(PC_SHIELD_PRESSED);
-						}
-						//if no airdodge, cancel into nspecial's recovery.
-						else {
-							window = 9;
-							window_timer = 0;
-						}
-					}
-				}
-
-				//stop charging if the special button is not held
-				else if (!special_down) {
-					window++;
-					window_timer = 0;
-					break;
-				}
-				
-				//charging sfx
-				if (naruto_nspecial_charge == 1 && naruto_nspecial_charge != c_naruto_nspecial_max_charge) {
-					voice_play(VB_RASENGAN_CHARGING);
-					naruto_nspecial_sound = sound_play(sound_get("snd_rasenganstartcharge"), 0, noone, 0.8, 1)
-				}
-				
-				//charge up
-				var check_full_charge = (naruto_nspecial_charge >= c_naruto_nspecial_max_charge);
-				naruto_nspecial_charge = min(naruto_nspecial_charge + 1, c_naruto_nspecial_max_charge);
-				if (!check_full_charge && naruto_nspecial_charge >= c_naruto_nspecial_max_charge) {
-					voice_play(VB_RASENGAN_FULLCHARGE);
-				}
-			break;
-			
-			case 6:
-				//limit fall speed
-				vsp = min(vsp, c_naruto_nspecial_max_fall_speed);
-				
-				//play voice sfx at end of window
-				if (!is_end_of_window()) break;
-				if (naruto_nspecial_charge >= c_naruto_nspecial_max_charge) voice_play(VB_RASENGAN_MAX);
-				else voice_play(VB_RASENGAN);
-			break;
-			
-		}
+        case AT_NSPECIAL:
+                // simplified rasengan dash special
+                doing_naruto_rasengan = true;
+                can_move = false;
+                switch (window) {
+                        case 1:
+                                rasengan_charge = 0;
+                                beam_juice = 0;
+                        break;
+                        case 2:
+                                vsp = min(vsp, 4);
+                                if (special_down && rasengan_charge < rasengan_charge_max) {
+                                        rasengan_charge++;
+                                        beam_juice = min(beam_juice + 1, beam_juice_max);
+                                } else {
+                                        window = 3;
+                                        window_timer = 0;
+                                }
+                        break;
+                        case 3:
+                                if (window_timer == 1) {
+                                        hsp = spr_dir * (4 + rasengan_charge * 0.1);
+                                }
+                                if (window_timer > 4) {
+                                        window = 4;
+                                        window_timer = 0;
+                                }
+                        break;
+                        case 4:
+                                hsp = spr_dir * (4 + rasengan_charge * 0.1);
+                                beam_juice = max(beam_juice - 1, 0);
+                                if (!special_down || beam_juice <= 0) {
+                                        window = 5;
+                                        window_timer = 0;
+                                }
+                        break;
+                        case 5:
+                                // finisher window
+                        break;
+                        default:
+                                doing_naruto_rasengan = false;
+                        break;
+                }
+        break;
 	break;
 	
 	case AT_NSPECIAL_2:

--- a/Naruto/scripts/attacks/nspecial.gml
+++ b/Naruto/scripts/attacks/nspecial.gml
@@ -1,202 +1,82 @@
-//----------------------------------------------------------------------------------------------------
-// NSPECIAL
-//----------------------------------------------------------------------------------------------------
-
-//rasengan
-
 set_attack_value(AT_NSPECIAL, AG_CATEGORY, 2);
 set_attack_value(AT_NSPECIAL, AG_SPRITE, sprite_get("nspecial"));
-set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 10);
+set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 8);
+set_attack_value(AT_NSPECIAL, AG_HAS_LANDING_LAG, 4);
+set_attack_value(AT_NSPECIAL, AG_OFF_LEDGE, 1);
+set_attack_value(AT_NSPECIAL, AG_AIR_SPRITE, sprite_get("nspecial_air"));
 set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, sprite_get("nspecial_hurt"));
 
-
-//startup
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 2);
+// startup
+set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 10);
 set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAME_START, 0);
 
-//summon clone if necessary
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 2);
+// charge loop
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 3);
 set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 2);
 
-//; wait until clone is ready
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_TYPE, 9); //infinitely-repeating window
+// dash startup
 set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 2);
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 6);
 
-//startup 2
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 3);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 4);
+// dash loop
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_TYPE, 9);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 7);
 
-//charge rasengan
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_TYPE, 9); //infinitely-repeating window
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 6);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 5);
+// finisher
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 5);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 1);
+set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 9);
 
-//fire rasengan startup
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 7);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED, 4);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HAS_SFX, 1);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_SFX, asset_get("sfx_forsburn_cape_swipe"));
+// endlag
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 3);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 9);
 
-//fire rasengan active
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 6);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 9);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED, 3);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 7, AG_WINDOW_VSPEED_TYPE, 1);
+// endlag pt 2
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 2);
+set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 12);
 
-//recovery 1  (hold pose)
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_LENGTH, 10);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_ANIM_FRAME_START, 12);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_VSPEED_TYPE, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED, 1);
-set_window_value(AT_NSPECIAL, 8, AG_WINDOW_HSPEED_TYPE, 2);
+set_num_hitboxes(AT_NSPECIAL, 2);
 
-//recovery 2
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 9, AG_WINDOW_ANIM_FRAME_START, 13);
-
-//recovery 3
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_LENGTH, 4);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAMES, 1);
-set_window_value(AT_NSPECIAL, 10, AG_WINDOW_ANIM_FRAME_START, 14);
-
-
-//--------------------
-// NSPECIAL Hitboxes
-//--------------------
-
-
-set_num_hitboxes(AT_NSPECIAL, 3);
-
-//rasengan - initial hitbox
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 7);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_X, 24);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_Y, -24);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 64);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 8); //must be higher than 1
+set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 4);
+set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 80);
+set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 80);
+set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 1, HG_PRIORITY, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_DAMAGE, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 30);
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 6);
-set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE, 70);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_KNOCKBACK, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_KNOCKBACK_SCALING, 0);
+set_hitbox_value(AT_NSPECIAL, 1, HG_BASE_HITPAUSE, 3);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT_Y_OFFSET, -16);
+set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.00001);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
+set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 1);
 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_ANIM_SPEED, 0.5); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_HSPEED, 15); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 1, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 1, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - travelling multihit hitbox - spawned in hit_player.gml
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 30);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_Y, -30);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 64);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HEIGHT, 64);
-set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 5); //must be higher than 1
-set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 90);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HEIGHT, 90);
+set_hitbox_value(AT_NSPECIAL, 2, HG_SHAPE, 2);
+set_hitbox_value(AT_NSPECIAL, 2, HG_PRIORITY, 4);
+set_hitbox_value(AT_NSPECIAL, 2, HG_DAMAGE, 4);
 set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE, 45);
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 9); //hit in direction of projectile
-set_hitbox_value(AT_NSPECIAL, 2, HG_SDI_MULTIPLIER, 0.01); //prevent too much wiggling out of multihits
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 2);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT_Y_OFFSET, -16);
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, 8);
+set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0.9);
+set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_HITPAUSE, 9);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HITPAUSE_SCALING, 0.5);
+set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 304);
+set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ANIM_SPEED, 0.33); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_MASK, -1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED, 5); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_IS_TRANSCENDENT, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_ENEMY_BEHAVIOR, 1); //goes through players - important 
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 0);
-
-set_hitbox_value(AT_NSPECIAL, 2, HG_BASE_KNOCKBACK, get_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_HSPEED)); //knockback speed = travel speed
-set_hitbox_value(AT_NSPECIAL, 2, HG_KNOCKBACK_SCALING, 0); //important
-set_hitbox_value(AT_NSPECIAL, 2, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
-set_hitbox_value(AT_NSPECIAL, 2, HG_TECHABLE, 1); //can't ground tech
-
-//rasengan - final hitbox - spawned in hitbox.gml upon hitbox #2's final hit
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_TYPE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW, 20);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WINDOW_CREATION_FRAME, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_LIFETIME, 4);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_X, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITBOX_Y, -30);
-set_hitbox_value(AT_NSPECIAL, 3, HG_WIDTH, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HEIGHT, 70);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SHAPE, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PRIORITY, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_DAMAGE, 2);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE, 55);
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 8); //hit towards projectile
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_KNOCKBACK, 8); //adjust as needed
-set_hitbox_value(AT_NSPECIAL, 3, HG_KNOCKBACK_SCALING, 0.9); //important
-set_hitbox_value(AT_NSPECIAL, 3, HG_BASE_HITPAUSE, 9);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HITPAUSE_SCALING, 0.5);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT_Y_OFFSET, -16);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_ANGLE_FLIPPER, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_VISUAL_EFFECT, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_HIT_LOCKOUT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_SDI_MULTIPLIER, 1); 
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_SPRITE, sprite_get("vfx_rasengan"));
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ANIM_SPEED, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_MASK, -1);
-
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_DESTROY_EFFECT, 14); //14 = 'smoke small'
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_HSPEED, 8); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_VSPEED, 0); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_IS_TRANSCENDENT, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_ENEMY_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_GROUND_BEHAVIOR, 1);
-set_hitbox_value(AT_NSPECIAL, 3, HG_IGNORES_PROJECTILES, 0);
-set_hitbox_value(AT_NSPECIAL, 3, HG_PROJECTILE_PARRY_STUN, 1); 
-set_hitbox_value(AT_NSPECIAL, 3, HG_EXTENDED_PARRY_STUN, 1); //inflict extended parry stun
+set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1);
+set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 1);

--- a/Naruto/scripts/hit_player.gml
+++ b/Naruto/scripts/hit_player.gml
@@ -67,16 +67,16 @@ case AT_NSPECIAL:
 			//pass on the charge strength of this projectile.
 			rasen.proj_nspecial_charge = my_hitboxID.proj_nspecial_charge;
 		//break;
-		case 2:
-			//multihit projectile: drag player towards projectile.
-			
-			
-			if (hit_player_obj.state_cat == SC_HITSTUN) {
-				hit_player_obj.x += round((my_hitboxID.x - hit_player_obj.x) * my_hitboxID.proj_magnet_strength);
-				var half_height = clamp(round(hit_player_obj.char_height / 2), 20, 50);
-				hit_player_obj.y += round(((my_hitboxID.y + half_height) - hit_player_obj.y) * my_hitboxID.proj_magnet_strength);
-			}
-		break;
+                case 2:
+                        // multihit projectile: drag player towards projectile.
+                        if (hit_player_obj.state_cat == SC_HITSTUN) {
+                                hit_player_obj.x += round((my_hitboxID.x - hit_player_obj.x) * my_hitboxID.proj_magnet_strength);
+                                var half_height = clamp(round(hit_player_obj.char_height / 2), 20, 50);
+                                hit_player_obj.y += round(((my_hitboxID.y + half_height) - hit_player_obj.y) * my_hitboxID.proj_magnet_strength);
+                        }
+                        rasengan_hit_count += 1;
+                        my_hitboxID.damage = 1 + floor(rasengan_hit_count * 0.5);
+                break;
 	}
 
 }

--- a/Naruto/scripts/init.gml
+++ b/Naruto/scripts/init.gml
@@ -93,6 +93,18 @@ if (!custom_clone) {
 	dspecial_clones_out = 0;
 	dspecial_clone_out = 0;
     naruto_clone_despawn_article = noone; //reference of the article that will safely despawn clones. spawned in user_event3.gml.
+
+    //rasengan / beam variables
+    beam_juice = 0;
+    beam_juice_max = 100;
+    beam_length = 0;
+    beam_clash_buddy = noone;
+    beam_clash_timer = 0;
+    beam_clash_timer_max = 180;
+    doing_naruto_rasengan = false;
+    rasengan_charge = 0;
+    rasengan_charge_max = 60;
+    rasengan_hit_count = 0;
     
     //move index constants. 
     //each clone needs their own index for certain moves.


### PR DESCRIPTION
## Summary
- implement basic rasengan dash attack logic
- define rasengan/beam variables in `init.gml`
- create new windows and hitboxes for Naruto nspecial
- track multihit combo damage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884af8998a8833289cddcd6e7ddc72d