### PR TITLE
Implement charged Rasengan dash

### DIFF
--- a/Naruto/scripts/attacks/nspecial.gml
+++ b/Naruto/scripts/attacks/nspecial.gml
@@ -1,44 +1,10 @@
 set_attack_value(AT_NSPECIAL, AG_CATEGORY, 2);
 set_attack_value(AT_NSPECIAL, AG_SPRITE, sprite_get("nspecial"));
-set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 6);
 set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 7);
-set_attack_value(AT_NSPECIAL, AG_NUM_WINDOWS, 8);
 set_attack_value(AT_NSPECIAL, AG_HAS_LANDING_LAG, 4);
 set_attack_value(AT_NSPECIAL, AG_OFF_LEDGE, 1);
 set_attack_value(AT_NSPECIAL, AG_AIR_SPRITE, sprite_get("nspecial_air"));
 set_attack_value(AT_NSPECIAL, AG_HURTBOX_SPRITE, sprite_get("nspecial_hurt"));
-
-// startup - show frames 0-4 once
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 5);
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAMES, 5);
-set_window_value(AT_NSPECIAL, 1, AG_WINDOW_ANIM_FRAME_START, 0);
-
-// charge loop - loop frames 6 and 7
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_TYPE, 9);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 12);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 5);
-
-// dash loop - frames 8 and 9
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_TYPE, 9);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 12);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 7);
-
-// finisher frames 10-15
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 6);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 6);
-set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 9);
-
-// endlag
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 12);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 3);
-set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 9);
-
-// endlag pt 2
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 12);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 2);
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 12);
 
 // startup
 set_window_value(AT_NSPECIAL, 1, AG_WINDOW_LENGTH, 10);
@@ -50,16 +16,18 @@ set_window_value(AT_NSPECIAL, 2, AG_WINDOW_LENGTH, 12);
 set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAMES, 3);
 set_window_value(AT_NSPECIAL, 2, AG_WINDOW_ANIM_FRAME_START, 2);
 
-// dash startup
+// post-charge
 set_window_value(AT_NSPECIAL, 3, AG_WINDOW_LENGTH, 4);
 set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAMES, 1);
 set_window_value(AT_NSPECIAL, 3, AG_WINDOW_ANIM_FRAME_START, 6);
 
-// dash loop
+// dash
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_TYPE, 9);
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_LENGTH, 12);
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAMES, 2);
 set_window_value(AT_NSPECIAL, 4, AG_WINDOW_ANIM_FRAME_START, 7);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_HSPEED_TYPE, 1);
+set_window_value(AT_NSPECIAL, 4, AG_WINDOW_HSPEED, 6);
 
 // finisher
 set_window_value(AT_NSPECIAL, 5, AG_WINDOW_LENGTH, 5);
@@ -67,7 +35,7 @@ set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAMES, 1);
 set_window_value(AT_NSPECIAL, 5, AG_WINDOW_ANIM_FRAME_START, 9);
 
 // endlag
-set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 12);
+set_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH, 12); // will scale in atk update
 set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAMES, 3);
 set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 9);
 
@@ -75,15 +43,15 @@ set_window_value(AT_NSPECIAL, 6, AG_WINDOW_ANIM_FRAME_START, 9);
 set_window_value(AT_NSPECIAL, 7, AG_WINDOW_LENGTH, 12);
 set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAMES, 2);
 set_window_value(AT_NSPECIAL, 7, AG_WINDOW_ANIM_FRAME_START, 12);
+
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_ENDLAG, string(get_window_value(AT_NSPECIAL, 6, AG_WINDOW_LENGTH)));
+set_attack_value(AT_NSPECIAL, AG_MUNO_ATTACK_MISC_ADD, "Endlag increases with charge.");
+
 set_num_hitboxes(AT_NSPECIAL, 2);
 
 set_hitbox_value(AT_NSPECIAL, 1, HG_HITBOX_TYPE, 1);
-set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 3);
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 9999999); // active through the entire dash
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 12);
 set_hitbox_value(AT_NSPECIAL, 1, HG_WINDOW, 4);
 set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 12);
-set_hitbox_value(AT_NSPECIAL, 1, HG_LIFETIME, 1);
 set_hitbox_value(AT_NSPECIAL, 1, HG_WIDTH, 80);
 set_hitbox_value(AT_NSPECIAL, 1, HG_HEIGHT, 80);
 set_hitbox_value(AT_NSPECIAL, 1, HG_SHAPE, 2);
@@ -102,7 +70,6 @@ set_hitbox_value(AT_NSPECIAL, 1, HG_EXTENDED_PARRY_STUN, 1);
 set_hitbox_value(AT_NSPECIAL, 1, HG_IGNORES_PROJECTILES, 1);
 
 set_hitbox_value(AT_NSPECIAL, 2, HG_HITBOX_TYPE, 1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 4);
 set_hitbox_value(AT_NSPECIAL, 2, HG_WINDOW, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_LIFETIME, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_WIDTH, 90);
@@ -121,5 +88,4 @@ set_hitbox_value(AT_NSPECIAL, 2, HG_VISUAL_EFFECT, 304);
 set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_LOCKOUT, 5);
 set_hitbox_value(AT_NSPECIAL, 2, HG_HIT_SFX, asset_get("sfx_blow_medium2"));
 set_hitbox_value(AT_NSPECIAL, 2, HG_EXTENDED_PARRY_STUN, 1);
-set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 1);
 set_hitbox_value(AT_NSPECIAL, 2, HG_IGNORES_PROJECTILES, 1);


### PR DESCRIPTION
## Summary
- redesign Naruto's nspecial to mirror Goku's staged beam setup
- add charging, dash distance scaling and endlag scaling
- implement clash logic with beams and dash hitboxes

## Testing
- `No tests`

------
https://chatgpt.com/codex/tasks/task_e_68869565e07883328cde6f6482fa70c7