### PR TITLE
Adjust Rasengan dash speed dynamically

### DIFF
--- a/Naruto/scripts/attack_update.gml
+++ b/Naruto/scripts/attack_update.gml
@@ -375,9 +375,11 @@ switch(attack) {
 				vsp = min(vsp, c_naruto_nspecial_max_fall_speed);
 				
 				//dash based on charge amount
-				if (window_timer == 1) {
-					var dash_speed = 4 + (naruto_nspecial_charge / c_naruto_nspecial_max_charge) * 12; // 4-16 speed based on charge
-					hsp = dash_speed * spr_dir;
+                                if (window_timer == 1) {
+                                        var dash_speed = 4 + (naruto_nspecial_charge / c_naruto_nspecial_max_charge) * 12; // 4-16 speed based on charge
+                                        set_window_value(AT_NSPECIAL, 6, AG_WINDOW_HSPEED, dash_speed);
+                                        set_window_value(AT_NSPECIAL, 7, AG_WINDOW_HSPEED, dash_speed);
+                                        hsp = dash_speed * spr_dir;
 					
 					//initialize clash system variables (both rasengan and beam compatibility)
 					rasengan_length = 60 + (naruto_nspecial_charge / c_naruto_nspecial_max_charge) * 100; // 60-160 clash power based on charge


### PR DESCRIPTION
## Summary
- ensure NSPECIAL dash uses correct speed on initial frames

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68885028b0f48332af71fca5e8e48d66